### PR TITLE
Fix Phantom login flow on mobile

### DIFF
--- a/src/components/grasschain_contract_spl/LoginIsland.tsx
+++ b/src/components/grasschain_contract_spl/LoginIsland.tsx
@@ -4,10 +4,12 @@
 import Image from "next/image";
 import { signIn, useSession } from "next-auth/react";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export default function LoginIsland() {
   const { data: session, status } = useSession();
   const { setVisible } = useWalletModal();
+  const isMobile = useIsMobile();
 
   // If the user is already logged in (or auth status is still loading), don't show this overlay
   if (session || status === "loading") return null;
@@ -56,7 +58,14 @@ export default function LoginIsland() {
           Web3:
         </div>
         <button
-          onClick={() => setVisible(true)}
+          onClick={() => {
+            if (isMobile) {
+              const url = `https://phantom.app/ul/browse/${encodeURIComponent(window.location.href)}`;
+              window.location.href = url;
+            } else {
+              setVisible(true);
+            }
+          }}
           className="
             w-full
             bg-gradient-to-r from-purple-600 to-blue-600


### PR DESCRIPTION
## Summary
- open Phantom via deep link if user is on mobile

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684178d623c8832484a799f8100ca37c