### PR TITLE
Set mobile sections to full viewport height

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -8,7 +8,7 @@ export default function AccountPage() {
   const { publicKey, disconnect } = useWallet();
 
   return (
-    <div className="px-4 md:px-8 space-y-6">
+    <div className="min-h-screen px-4 md:px-8 space-y-6">
       {session?.user?.email || publicKey ? (
         <div className="space-y-4">
           {session?.user?.email && (

--- a/src/components/tracking/overlayLayout.tsx
+++ b/src/components/tracking/overlayLayout.tsx
@@ -23,7 +23,7 @@ export default function OverlayLayout({ children }: OverlayLayoutProps) {
   const loteBgClass = isStats ? "bg-white" : "bg-white/75";
 
   return (
-    <div className="relative flex-1 overflow-hidden">
+    <div className="relative flex-1 overflow-hidden min-h-screen">
       {/* full-screen map in the back */}
       <div className="absolute inset-0 z-0">
         <MapComponent sidebarOpen={sidebarOpen} />


### PR DESCRIPTION
## Summary
- ensure `/account` fills the mobile screen
- make tracking overlay layout stretch to full screen

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684734a6e6408324a90b3fb084478079