### PR TITLE
chore: switch map to pure Mapbox GL

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,6 +8,7 @@ import { SolanaProvider } from "@/components/solana/solana-provider";
 // add these:
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import "@solana/wallet-adapter-react-ui/styles.css";
+import "mapbox-gl/dist/mapbox-gl.css";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- initialize Mapbox GL map with custom style and env token
- disable Mapbox telemetry and guard against multiple instances
- import Mapbox CSS globally in providers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5ed44b7483249d0a8a0e26272956